### PR TITLE
Fix breadcrumb current-page accent styling

### DIFF
--- a/src/main/webapp/spectrum-base.css
+++ b/src/main/webapp/spectrum-base.css
@@ -138,8 +138,8 @@ html[data-theme^="spectrum-"] .task-link:hover {
   color: var(--instance-accent) !important;
 }
 
-html[data-theme^="spectrum-"] [aria-current="page"],
-html[data-theme^="spectrum-"] .jenkins-breadcrumbs__list-item a[aria-current="page"] {
+html[data-theme^="spectrum-"] .jenkins-breadcrumbs__list-item[aria-current="page"],
+html[data-theme^="spectrum-"] .jenkins-breadcrumbs__list-item [aria-current="page"] {
   color: var(--instance-accent) !important;
   font-weight: 600;
 }

--- a/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/AppearancePage.java
+++ b/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/AppearancePage.java
@@ -39,6 +39,43 @@ public class AppearancePage extends JenkinsPage<AppearancePage> {
         return this;
     }
 
+    public AppearancePage injectCurrentPageFixtures() {
+        log.info("Injecting breadcrumb and pagination fixtures");
+        page.evaluate("""
+            () => {
+              document.querySelector('#accent-scope-fixtures')?.remove();
+              document.body.insertAdjacentHTML('beforeend', `
+                <section id="accent-scope-fixtures" style="margin: 24px; display: grid; gap: 12px;">
+                  <nav class="jenkins-breadcrumbs" aria-label="Breadcrumb">
+                    <ol class="jenkins-breadcrumbs__list" style="color: rgb(11, 22, 33);">
+                      <li class="jenkins-breadcrumbs__list-item">
+                        <span id="test-breadcrumb-current" aria-current="page">Current breadcrumb</span>
+                      </li>
+                    </ol>
+                  </nav>
+                  <nav aria-label="Pagination" style="color: rgb(44, 55, 66); font-weight: 400;">
+                    <span id="test-pagination-current" aria-current="page">2</span>
+                  </nav>
+                </section>
+              `);
+            }""");
+        return this;
+    }
+
+    public AppearancePage breadcrumbCurrentPageUsesAccent() {
+        log.info("Checking that breadcrumb current-page styling uses the theme accent");
+        checkComputedStyle("#test-breadcrumb-current", "color", resolveColor("var(--instance-accent)"));
+        checkComputedStyle("#test-breadcrumb-current", "font-weight", "600");
+        return this;
+    }
+
+    public AppearancePage paginationCurrentPageKeepsLocalStyle() {
+        log.info("Checking that non-breadcrumb current-page styling keeps local styles");
+        checkComputedStyle("#test-pagination-current", "color", "rgb(44, 55, 66)");
+        checkComputedStyle("#test-pagination-current", "font-weight", "400");
+        return this;
+    }
+
     private Locator getThemeCard(Theme theme) {
         log.debug("Locating theme box for '{}'", theme);
         return page.getByRole(AriaRole.RADIO, new GetByRoleOptions().setName(theme.name()))

--- a/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/JenkinsPage.java
+++ b/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/JenkinsPage.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.theme.spectrum.playwright;
 
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.TimeoutError;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,5 +37,44 @@ abstract class JenkinsPage<T extends JenkinsPage<T>> {
             throw new TimeoutError(
                     "Timeout exceeding waiting for the url to be " + url + " but it was " + page.url(), e);
         }
+    }
+
+    protected void checkComputedStyle(String selector, String property, String expected) {
+        try {
+            page.waitForFunction("""
+        ([selector, property, expected]) => {
+          const el = document.querySelector(selector);
+          if (!el) return false;
+          return getComputedStyle(el).getPropertyValue(property).trim() === expected;
+        }""", List.of(selector, property, expected));
+        } catch (TimeoutError e) {
+            String value = computedStyle(selector, property);
+            throw new AssertionError(
+                    "Could not verify that computed style '%s' for '%s' was equal to '%s', found '%s'"
+                            .formatted(property, selector, expected, value),
+                    e);
+        }
+    }
+
+    protected String computedStyle(String selector, String property) {
+        return (String) page.evaluate("""
+            ([selector, property]) => {
+              const el = document.querySelector(selector);
+              if (!el) return null;
+              return getComputedStyle(el).getPropertyValue(property).trim();
+            }""", List.of(selector, property));
+    }
+
+    protected String resolveColor(String color) {
+        return (String) page.evaluate("""
+            (color) => {
+              const el = document.createElement('div');
+              el.style.color = color;
+              el.style.display = 'none';
+              document.body.appendChild(el);
+              const resolved = getComputedStyle(el).color;
+              el.remove();
+              return resolved;
+            }""", color);
     }
 }

--- a/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/SpectrumThemeTest.java
+++ b/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/SpectrumThemeTest.java
@@ -17,4 +17,15 @@ public class SpectrumThemeTest {
             appearancePage.themeIsPresent(theme).selectTheme(theme).themeIsApplied(theme);
         }
     }
+
+    @Test
+    void currentPageAccentIsScopedToBreadcrumbs(JenkinsRule j, Page p) {
+        new AppearancePage(p, j.jenkins.getRootUrl())
+                .goTo()
+                .selectTheme(Theme.SPECTRUM_BLUE)
+                .themeIsApplied(Theme.SPECTRUM_BLUE)
+                .injectCurrentPageFixtures()
+                .breadcrumbCurrentPageUsesAccent()
+                .paginationCurrentPageKeepsLocalStyle();
+    }
 }


### PR DESCRIPTION
This PR narrows the Spectrum theme current-page accent styling to breadcrumbs only.

Previously, the theme applied accent styling to any `[aria-current="page"]` element, which caused the active page in pagination controls to inherit the accent color. This change scopes the rule to breadcrumb items so that:

- breadcrumb current-page items keep the accent styling
- pagination current-page items no longer receive the accent color unintentionally

### Testing done
Added a Playwright regression test covering current-page accent scoping.

The new test verifies that:
- breadcrumb current-page items still use the Spectrum accent color
- non-breadcrumb `[aria-current="page"]` items do not inherit the accent color or font weight

Test command run:

```bash
mvn -Dtest=SpectrumThemeTest test
```

Result:

- Passed

This coverage was added in SpectrumThemeTest#currentPageAccentIsScopedToBreadcrumbs.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed