### PR TITLE
Fix button link accent contrast

### DIFF
--- a/src/main/webapp/spectrum-base.css
+++ b/src/main/webapp/spectrum-base.css
@@ -132,9 +132,9 @@ html[data-theme^="spectrum-"] button.jenkins-button--primary {
   color: var(--action-primary-text) !important;
 }
 
-html[data-theme^="spectrum-"] a:hover,
-html[data-theme^="spectrum-"] .jenkins-link:hover,
-html[data-theme^="spectrum-"] .task-link:hover {
+html[data-theme^="spectrum-"] a:not(.jenkins-button):hover,
+html[data-theme^="spectrum-"] .jenkins-link:not(.jenkins-button):hover,
+html[data-theme^="spectrum-"] .task-link:not(.jenkins-button):hover {
   color: var(--instance-accent) !important;
 }
 
@@ -154,6 +154,17 @@ html[data-theme^="spectrum-"] .tabBar .tab a[aria-selected="true"],
 html[data-theme^="spectrum-"] .tabBar .tab a[aria-current="page"] {
   background: color-mix(in srgb, var(--background) 94%, var(--instance-accent)) !important;
   box-shadow: inset 0 -1px 0 0 var(--instance-accent) !important;
+}
+
+/* Keep button labels and counts readable when selected/pressed states switch to a blue action surface. */
+html[data-theme^="spectrum-"] .jenkins-button[aria-current="page"],
+html[data-theme^="spectrum-"] .jenkins-button[aria-pressed="true"] {
+  color: var(--action-primary-text) !important;
+}
+
+html[data-theme^="spectrum-"] .jenkins-button[aria-current="page"] *,
+html[data-theme^="spectrum-"] .jenkins-button[aria-pressed="true"] * {
+  color: inherit !important;
 }
 
 .app-theme-picker__item input:checked + label .app-theme-picker__picker[data-theme^="spectrum-"] {

--- a/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/AppearancePage.java
+++ b/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/AppearancePage.java
@@ -40,7 +40,7 @@ public class AppearancePage extends JenkinsPage<AppearancePage> {
     }
 
     public AppearancePage injectCurrentPageFixtures() {
-        log.info("Injecting breadcrumb and pagination fixtures");
+        log.info("Injecting breadcrumb, pagination, and button/link contrast fixtures");
         page.evaluate("""
             () => {
               document.querySelector('#accent-scope-fixtures')?.remove();
@@ -56,6 +56,26 @@ public class AppearancePage extends JenkinsPage<AppearancePage> {
                   <nav aria-label="Pagination" style="color: rgb(44, 55, 66); font-weight: 400;">
                     <span id="test-pagination-current" aria-current="page">2</span>
                   </nav>
+                  <button
+                    id="test-pressed-button"
+                    class="jenkins-button"
+                    type="button"
+                    aria-pressed="true"
+                    style="background: rgb(37, 99, 235); border: 1px solid rgb(37, 99, 235); color: rgb(255, 255, 255) !important;"
+                  >
+                    Builds
+                    <span id="test-pressed-button-count" style="color: var(--instance-accent); font-weight: 600;">2</span>
+                  </button>
+                  <a
+                    id="test-pressed-link"
+                    class="jenkins-button jenkins-submit-button jenkins-button--primary secret-guard-filter-link secret-guard-results-link"
+                    href="#"
+                    aria-pressed="true"
+                    style="background: rgb(37, 99, 235); border: 1px solid rgb(37, 99, 235); color: rgb(255, 255, 255) !important; display: inline-flex; gap: 4px; text-decoration: none;"
+                  >
+                    With Findings
+                    <span id="test-pressed-link-count" style="color: var(--instance-accent); font-weight: 600;">(5)</span>
+                  </a>
                 </section>
               `);
             }""");
@@ -73,6 +93,26 @@ public class AppearancePage extends JenkinsPage<AppearancePage> {
         log.info("Checking that non-breadcrumb current-page styling keeps local styles");
         checkComputedStyle("#test-pagination-current", "color", "rgb(44, 55, 66)");
         checkComputedStyle("#test-pagination-current", "font-weight", "400");
+        return this;
+    }
+
+    public AppearancePage pressedButtonCountKeepsButtonContrast() {
+        log.info("Checking that pressed button counts inherit the button foreground");
+        checkComputedStyle("#test-pressed-button-count", "color", "rgb(255, 255, 255)");
+        return this;
+    }
+
+    public AppearancePage pressedLinkCountKeepsButtonContrast() {
+        log.info("Checking that pressed link-button counts inherit the button foreground");
+        checkComputedStyle("#test-pressed-link-count", "color", "rgb(255, 255, 255)");
+        return this;
+    }
+
+    public AppearancePage hoveredPrimaryLinkKeepsButtonContrast() {
+        log.info("Checking that hovered primary link-buttons do not switch back to the accent color");
+        page.locator("#test-pressed-link").hover();
+        checkComputedStyle("#test-pressed-link", "color", "rgb(255, 255, 255)");
+        checkComputedStyle("#test-pressed-link-count", "color", "rgb(255, 255, 255)");
         return this;
     }
 

--- a/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/SpectrumThemeTest.java
+++ b/src/test/java/io/jenkins/plugins/theme/spectrum/playwright/SpectrumThemeTest.java
@@ -26,6 +26,9 @@ public class SpectrumThemeTest {
                 .themeIsApplied(Theme.SPECTRUM_BLUE)
                 .injectCurrentPageFixtures()
                 .breadcrumbCurrentPageUsesAccent()
-                .paginationCurrentPageKeepsLocalStyle();
+                .paginationCurrentPageKeepsLocalStyle()
+                .pressedButtonCountKeepsButtonContrast()
+                .pressedLinkCountKeepsButtonContrast()
+                .hoveredPrimaryLinkKeepsButtonContrast();
     }
 }


### PR DESCRIPTION
Fix primary button-link contrast in Spectrum Theme

This change fixes a contrast regression for primary actions rendered as `<a>` elements, such as Secret Guard filter links like `With Findings (5)`.

What changed:
- excluded `.jenkins-button` links from the theme-wide link hover accent rule so primary button links no longer switch back to the accent color on hover
- kept selected/pressed `.jenkins-button` text and inline counts inheriting the button foreground color
- added Playwright coverage for button and link-button contrast behavior, while preserving the existing breadcrumb accent scoping check

### Testing done

Automated:
- Ran `mvn -Dtest=SpectrumThemeTest test`

This test now exercises:
- breadcrumb current-page accent scoping
- non-breadcrumb `aria-current="page"` text keeping its local color
- pressed button count text keeping button contrast
- pressed primary link-button count text keeping button contrast
- hovered primary link-button text and count not switching back to the accent color

Manual/frontend validation:
- Verified the problematic primary link-button pattern:
  `<a class="jenkins-button jenkins-submit-button jenkins-button--primary ...">With Findings (5)</a>`
- Confirmed that on a blue primary button background, both the label and count remain readable instead of reverting to the theme accent color

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed